### PR TITLE
chore: add .eslintcache to .gitignore

### DIFF
--- a/Sugar_Cosmetic/.gitignore
+++ b/Sugar_Cosmetic/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.eslintcache


### PR DESCRIPTION
This change updates the .gitignore file to include the .eslintcache file, which is generated by ESLint to store information about linting results. Ignoring this file helps to keep the repository clean and avoids unnecessary clutter from temporary files.